### PR TITLE
Add full fine-tune support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ batch_size: 16
 max_steps: 2000
 ```
 
+#### 📌 Full fine-tuning (no LoRA):
+Use the provided `example/moshi_7B_full.yaml` configuration or set the following options:
+```
+full_finetuning: true
+lora:
+  enable: false
+save_adapters: false
+```
+Run training as follows:
+```sh
+torchrun --nproc-per-node 1 -m train example/moshi_7B_full.yaml
+```
+
 #### 📌 Run training on a single GPU:
 
 ```sh
@@ -184,8 +197,10 @@ If you encounter **out-of-memory errors**, try reducing the `batch_size`. If the
 
 ## ⚙️ Customizing training configuration
 
-The example `moshi-finetune/example/moshi_7B.yaml` defines reasonable parameters for learning rate, weight decay, etc... but you are advised to
-customize these settings for your use case.
+The examples `moshi-finetune/example/moshi_7B.yaml` (LoRA) and
+`moshi-finetune/example/moshi_7B_full.yaml` (full fine-tuning) provide
+reasonable starting parameters, but you are advised to customize these
+settings for your use case.
 
 
 ### 🔧 Key training parameters

--- a/example/moshi_7B_full.yaml
+++ b/example/moshi_7B_full.yaml
@@ -1,0 +1,49 @@
+# data
+data:
+  eval_data: '' # Optional Fill
+  shuffle: true
+  train_data: '' # Fill
+
+# model
+moshi_paths: 
+  hf_repo_id: "kyutai/moshiko-pytorch-bf16"
+
+full_finetuning: true # Train all model weights
+lora:
+  enable: false # LoRA disabled for full fine-tuning
+  rank: 128
+  scaling: 2.
+  ft_embed: false # Optional, set to True if you want to finetune the embedding layer
+
+first_codebook_weight_multiplier: 100.
+text_padding_weight: .5
+
+# optim
+duration_sec: 100
+batch_size: 16
+max_steps: 2000
+gradient_checkpointing: true
+optim:
+  lr: 2e-6
+  weight_decay: 0.1
+  pct_start: 0.05
+
+# other
+seed: 0
+log_freq: 1
+eval_freq: 100
+do_eval: false
+do_ckpt: true
+ckpt_freq: 100
+
+
+save_adapters: false # Save full model checkpoints
+
+run_dir: ""  # Fill
+
+# This part is optional and can be kept commented out
+# wandb:
+#   project: "" # your wandb project name
+#   run_name: "" # your wandb run name
+#   key: "" # your wandb api key
+#   offline: False

--- a/finetune/args.py
+++ b/finetune/args.py
@@ -129,3 +129,9 @@ class TrainArgs(Serializable):
                 "This might lead to OOM errors - make sure you have enough CPU "
                 "and GPU memory."
             )
+
+        if self.full_finetuning:
+            if self.lora.enable:
+                logging.warning("`full_finetuning` is True; disabling LoRA training")
+            self.lora.enable = False
+            self.save_adapters = False


### PR DESCRIPTION
## Summary
- allow enabling full fine-tuning via TrainArgs by disabling LoRA automatically
- document how to run full fine-tuning
- provide `moshi_7B_full.yaml` example configuration

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b310c86cc8330a64e62bbdf85bcf9